### PR TITLE
Added exception handling to CLI

### DIFF
--- a/ED4scan/ED4scan_CLI.ino
+++ b/ED4scan/ED4scan_CLI.ino
@@ -390,11 +390,13 @@ void set_cmd(uint8_t arg_cnt, char **args) {
       } else{
         cmdOK = 0;
       }
+    } else if (BMS.KeyState != 0) {
+      cmdOK = -2;
     }
   }
   if (cmdOK == 0) Serial.println(F("CMD: failed"));
-  if (cmdOK < 0) Serial.println(F("CMD: wrong format"));
-
+  if (cmdOK == -1) Serial.println(F("CMD: wrong format"));
+  if (cmdOK == -2) Serial.println(F("CMD: Ignition key in wrong position"));
 }
 
 void init_cmd_prompt() {


### PR DESCRIPTION
set_cmd with > 3 arguments used to throw "wrong format" exception with keystate == 1. Changed the exception message to a more helpful one.